### PR TITLE
Add a setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ You need to have the following things installed:
 - [siji font](https://github.com/stark/siji)
 - [herbstluftwm](https://github.com/herbstluftwm/herbstluftwm)
 - conky (only if you want to use the conky widget)
+- setuptools if installing via `setup.py`
 
 ## Usage in herbstluftwm
 To install it type:

--- a/barpyrus.py
+++ b/barpyrus.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
-import sys
 import barpyrus.mainloop
 
 if __name__ == '__main__':
-    sys.exit(barpyrus.mainloop.main(sys.argv))
+    sys.exit(barpyrus.mainloop.main())

--- a/barpyrus/mainloop.py
+++ b/barpyrus/mainloop.py
@@ -38,7 +38,7 @@ def user_config_path():
 def get_user_config():
     return get_config(user_config_path())
 
-def main(argv):
+def main():
     # import all locales
     locale.setlocale(locale.LC_ALL, '')
     # ---- configuration ---

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,29 @@
+from setuptools import setup, find_packages
+
+def read_file(name):
+    with open(name, 'r', encoding='utf-8') as f:
+        return f.read()
+
+
+setup(
+    name='barpyrus',
+    version='0.0.0',
+    description='A python wrapper for lemonbar/conky',
+    long_description=read_file('README.md'),
+    url='https://github.com/t-wissmann/barpyrus',
+    author='Thorsten Wißmann',
+    license='BSD',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Environment :: X11 Applications',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python :: 3',
+        'Topic :: Desktop Environment',
+    ],
+    packages=find_packages(include=['barpyrus']),
+    entry_points={
+        'console_scripts': [
+            'barpyrus=barpyrus.mainloop:main',
+        ],
+    },
+)


### PR DESCRIPTION
This also removes the (unused) sys.argv parameter to mainloop.main so it can be
used as a setuptools entry point. If we intend to use `sys.argv` later, we can
just use it directly in `mainloop.py` or use an argument with `sys.argv` as
default value.