### PR TITLE
Fix percentage escaping

### DIFF
--- a/barpyrus/lemonbar.py
+++ b/barpyrus/lemonbar.py
@@ -49,7 +49,7 @@ class Lemonbar(EventInput):
         def drawRaw(self, text):
             self.buf += text
         def text(self, text):
-            self.buf += text.replace('%', '%%{}')
+            self.buf += text.replace('%', '%%')
         def set_ul(self, enabled):
             self.buf += '%{+u}' if enabled else '%{-u}'
         def set_ol(self, enabled):


### PR DESCRIPTION
With an up-to-date lemonbar, escaping % as %%{} adds an additional {}, but %%
alone works fine.

See https://github.com/LemonBoy/bar/commit/1411d260a4c6956ff5a3699ee9bfd5b275209fe3