### PR TITLE
[merged] Make the lemonbar command configurable

### DIFF
--- a/barpyrus/lemonbar.py
+++ b/barpyrus/lemonbar.py
@@ -8,6 +8,7 @@ def textpainter():
 
 class Lemonbar(EventInput):
     def __init__(self, geometry = None,
+                 cmd = 'lemonbar',
                  font = '-*-fixed-medium-*-*-*-12-*-*-*-*-*-iso10646-1',
                  symbol_font = '-wuncon-siji-medium-r-normal--10-100-75-75-c-80-iso10646-1',
                  background = '#ee121212',
@@ -20,7 +21,7 @@ class Lemonbar(EventInput):
         #
         #   lemonbar_old_percent_escapes = True
         #
-        command = [ "lemonbar" ]
+        command = [ cmd ]
         if geometry:
             (x,y,w,h) = geometry
             command += [ '-g', "%dx%d%+d%+d" % (w,h,x,y)  ]


### PR DESCRIPTION
As the title says, this adds the ability to pass the lemonbar command in the `config.py`.

For example I use a [lemonbar fork](https://github.com/krypt-n/bar) with xft support which I have to compile myself under Ubuntu (at work) and have set the `cmd` parameter to the full path to the executable.