### PR TITLE
Also quit on the 'reload' hook of hlwm

### DIFF
--- a/barpyrus/hlwm.py
+++ b/barpyrus/hlwm.py
@@ -23,6 +23,7 @@ class HLWMInput(EventInput):
         self.hooks = { }
         super(HLWMInput,self).__init__(cmd)
         self.enhook('quit_panel', lambda args: quit_main_loop())
+        self.enhook('reload', lambda args: quit_main_loop())
     def enhook(self,name,callback):
         self.hooks.setdefault(name,[]).append(callback)
     def handle_line(self,line):


### PR DESCRIPTION
As the title says, this causes the panel to quit upon receiving the `reload` hook from herbstluftwm.
This is the same behavior as the example `panel.sh` of herbstluftwm.