### PR TITLE
Added symbol vert offset argument

### DIFF
--- a/barpyrus/lemonbar.py
+++ b/barpyrus/lemonbar.py
@@ -11,7 +11,10 @@ class Lemonbar(EventInput):
                  cmd = 'lemonbar',
                  font = '-*-fixed-medium-*-*-*-12-*-*-*-*-*-iso10646-1',
                  symbol_font = '-wuncon-siji-medium-r-normal--10-100-75-75-c-80-iso10646-1',
-                 symbol_vert_offset=0,
+                 # Setting symbol_vert_offset only works if the underlying lemonbar takes the flag `-o`
+                 # for adding a vertical offset for the text. E.g lemonbar-xft does this
+                 # https://github.com/drscream/lemonbar-xft
+                 symbol_vert_offset=None,
                  background = '#ee121212',
                  foreground = '#989898',
                  lemonbar_old_percent_escapes = False,
@@ -29,12 +32,15 @@ class Lemonbar(EventInput):
         command += '-a 100 -d -u 2'.split(' ')
         command += [ '-B', background  ]
         command += [ '-F', foreground  ]
-        command += [ '-o 0' ]
+        if symbol_vert_offset is not None:
+            command += [ '-o 0' ]
         command += [ '-f', font  ]
-        command += [ '-o 0' ]
+        if symbol_vert_offset is not None:
+            command += [ '-o 0' ]
         command += '-f -*-*-*-*-*-*-2-*-*-*-*-*-*-*'.split(' ')
         if symbol_font != None:
-            command += [ '-o -%d' % symbol_vert_offset ]
+            if symbol_vert_offset is not None:
+                command += [ '-o -%d' % symbol_vert_offset ]
             command += [ '-f', symbol_font ]
         command += args
         super(Lemonbar,self).__init__(command)

--- a/barpyrus/lemonbar.py
+++ b/barpyrus/lemonbar.py
@@ -11,6 +11,7 @@ class Lemonbar(EventInput):
                  cmd = 'lemonbar',
                  font = '-*-fixed-medium-*-*-*-12-*-*-*-*-*-iso10646-1',
                  symbol_font = '-wuncon-siji-medium-r-normal--10-100-75-75-c-80-iso10646-1',
+                 symbol_vert_offset=0,
                  background = '#ee121212',
                  foreground = '#989898',
                  lemonbar_old_percent_escapes = False,
@@ -28,9 +29,12 @@ class Lemonbar(EventInput):
         command += '-a 100 -d -u 2'.split(' ')
         command += [ '-B', background  ]
         command += [ '-F', foreground  ]
+        command += [ '-o 0' ]
         command += [ '-f', font  ]
+        command += [ '-o 0' ]
         command += '-f -*-*-*-*-*-*-2-*-*-*-*-*-*-*'.split(' ')
         if symbol_font != None:
+            command += [ '-o -%d' % symbol_vert_offset ]
             command += [ '-f', symbol_font ]
         command += args
         super(Lemonbar,self).__init__(command)


### PR DESCRIPTION
I find the symbols not really centered vertically so added an argument to shift them (while leaving the text as it is). Defaults to `0` (no change). A value of `2` works nice for me.