### PR TITLE
Update tag status when a tag was renamed

### DIFF
--- a/barpyrus/hlwm.py
+++ b/barpyrus/hlwm.py
@@ -172,11 +172,8 @@ class HLWMTags(Widget):
         self.activecolor = hlwm('attr theme.tiling.active.color'.split(' '))
         self.emphbg = '#303030'
         self.update_tags()
-        hlwm.enhook('tag_changed', lambda a: self.update_tags(args = a))
-        hlwm.enhook('tag_flags', lambda a: self.update_tags(args = a))
-        hlwm.enhook('tag_added', lambda a: self.update_tags(args = a))
-        hlwm.enhook('tag_removed', lambda a: self.update_tags(args = a))
-        hlwm.enhook('tag_renamed', lambda a: self.update_tags(args = a))
+        for event in ['tag_changed', 'tag_flags', 'tag_added', 'tag_removed', 'tag_renamed']:
+            hlwm.enhook(event, self.update_tags)
 
     def update_tags(self, args = None):
         strlist = self.hc(['tag_status', str(self.monitor)]).strip('\t').split('\t')

--- a/barpyrus/hlwm.py
+++ b/barpyrus/hlwm.py
@@ -176,6 +176,7 @@ class HLWMTags(Widget):
         hlwm.enhook('tag_flags', lambda a: self.update_tags(args = a))
         hlwm.enhook('tag_added', lambda a: self.update_tags(args = a))
         hlwm.enhook('tag_removed', lambda a: self.update_tags(args = a))
+        hlwm.enhook('tag_renamed', lambda a: self.update_tags(args = a))
 
     def update_tags(self, args = None):
         strlist = self.hc(['tag_status', str(self.monitor)]).strip('\t').split('\t')


### PR DESCRIPTION
Before, renaming a tag wouldn't display the new tag names. As a workaround, `hc emit_hook tag_flags` can be used after renaming a tag, but it's a bit of a hack.

This also adds a for loop (in a separate commit) to reduce duplication a bit and removes the unnecessary lambdas.

Also see https://github.com/herbstluftwm/herbstluftwm/issues/999 - but given that it doesn't use the hook's arguments, any change there should probably not matter much.