### PR TITLE
Handle EOF correctly

### DIFF
--- a/barpyrus/core.py
+++ b/barpyrus/core.py
@@ -38,8 +38,7 @@ class EventInput:
     def readlines(self):
         data = os.read(self.proc.stdout.fileno(), 4096).decode('utf-8')
         if not data:
-            # EOF
-            return None
+            raise EOFError
         self._buf += data
         if '\n' not in data:
             return []

--- a/barpyrus/mainloop.py
+++ b/barpyrus/mainloop.py
@@ -91,9 +91,12 @@ def main_loop(bar, inputs = None):
         if not data_ready:
             pass #print('timeout!')
         else:
-            for x in data_ready:
-                x.process()
-                global_update = True
+            try:
+                for x in data_ready:
+                    x.process()
+                    global_update = True
+            except EOFError:
+                break
     bar.proc.kill()
     for i in inputs:
         i.kill()


### PR DESCRIPTION
When e.g. doing "hc quit", one would get:

```
  Traceback (most recent call last):
    File ".../barpyrus/mainloop.py", line 47, in main
      main_loop(bar)
    File ".../barpyrus/mainloop.py", line 95, in main_loop
      x.process()
    File ".../barpyrus/core.py", line 50, in process
      for line in self.readlines():
  TypeError: 'NoneType' object is not iterable
```