### PR TITLE
Add support for xrandr module

### DIFF
--- a/barpyrus/widgets.py
+++ b/barpyrus/widgets.py
@@ -122,6 +122,16 @@ class Button(Widget):
         if self.callback:
             self.callback(button)
 
+class ToggleButton(Button):
+    def __init__(self, labels):
+        self.labels = labels
+        super().__init__(label=self.labels[0])
+        self.buttons = [1, 3]
+
+    def on_click(self, button):
+        super().on_click(button)
+        if button == 1:
+            self.label = self.labels[0]
 
 class DateTime(Label):
     def __init__(self,time_format = '%H:%M, %Y-%m-%d'):

--- a/barpyrus/widgets.py
+++ b/barpyrus/widgets.py
@@ -123,15 +123,15 @@ class Button(Widget):
             self.callback(button)
 
 class ToggleButton(Button):
-    def __init__(self, labels):
-        self.labels = labels
-        super().__init__(label=self.labels[0])
+    def __init__(self, cls):
+        self.cls = cls
+        super().__init__(label=self.cls.displayed)
         self.buttons = [1, 3]
 
     def on_click(self, button):
         super().on_click(button)
         if button == 1:
-            self.label = self.labels[0]
+            self.label = self.cls.displayed
 
 class DateTime(Label):
     def __init__(self,time_format = '%H:%M, %Y-%m-%d'):

--- a/barpyrus/xrandr.py
+++ b/barpyrus/xrandr.py
@@ -7,12 +7,13 @@ from itertools import combinations
 class Xrandr:
     def __init__(self):
         self.connected = list()
-        self.active_layout = list()
+        self.active_layout = None
+        self.active_mode = "+"
         self.disconnected = list()
-        setattr(self, 'DP2-1_pos', 'left-of eDP1')
-        setattr(self, 'DP2-1_resolution', '1920x1080')
+        self.displayed = None
 
     def get_layout(self):
+        active_layout = list()
         proc = subprocess.run(["xrandr"], capture_output=True)
         for line in proc.stdout.decode().splitlines():
             s = line.split(" ")
@@ -21,7 +22,7 @@ class Xrandr:
                 for index, x in enumerate(s[2:], 2):
                     if "x" in x and "+" in x:
                         mode = x
-                        self.active_layout.append(output)
+                        active_layout.append(output)
                         infos = line[line.find(s[index + 1]) :]
                         break
                     elif "(" in x:
@@ -31,6 +32,8 @@ class Xrandr:
                 output, state = s[0], s[1]
                 self.disconnected.append(output)
     
+        if self.active_layout is None:
+            self.active_layout = self.active_mode.join(tuple(active_layout))
         return self.connected
 
     def set_combinations(self, connected):
@@ -52,50 +55,75 @@ class Xrandr:
 
         return self.available_combinations
     
+    def choose_what_to_display(self):
+        for _ in range(len(self.available_combinations)):
+            if self.displayed is None and self.available_combinations[0] == self.active_layout:
+                self.displayed = self.available_combinations[0]
+                break
+            elif self.displayed == self.available_combinations[0]:
+                break
+            else:
+                self.available_combinations.rotate(1)
+
+    def switch_selection(self):
+        self.available_combinations.rotate()
+        self.displayed = self.available_combinations[0]
+
+    def apply(self):
+        print("displayed " + self.displayed)
+        print("active " + self.active_layout)
+        if self.displayed == self.active_layout:
+            return
+
+        combination, mode = self.combinations_map.get(self.displayed, (None, None))
+
+        if combination is None and mode is None:
+        # displayed combination cannot be activated, ignore
+          return
+
+        cmd = "xrandr"
+        outputs = self.connected
+        previous_output = None
+        for output in outputs:
+            cmd += f" --output {output}"
+            if output in combination:
+                pos = getattr(self, f"{output}_pos", "0x0")
+                resolution = getattr(self, f"{output}_mode", None)
+                resolution = f"--mode {resolution}" if resolution else "--auto"
+                rotation = "normal"
+                if mode == "=" and previous_output is not None:
+                    cmd += f" {resolution} --same-as {previous_output}"
+                else:
+                    if (
+                        "above" in pos
+                        or "below" in pos
+                        or "left-of" in pos
+                        or "right-of" in pos
+                       ):
+                        cmd += f" {resolution} --{pos} --rotate {rotation}"
+                    else:
+                        cmd += " {} --pos {} --rotate {}".format(
+                            resolution, pos, rotation
+                        )
+                previous_output = output
+            else:
+                cmd += " --off"
+
+        code = subprocess.run(cmd.split())
+
+        if code.returncode == 0:
+            self.active_layout = self.displayed
+            self.active_mode = mode
+        print(cmd)
+        print(code)
+
     def on_click(self, button):
         print(button)
 
         if button == 1:
           print("before %s", self.available_combinations[0])
-          self.available_combinations.rotate()
+          self.switch_selection()
           print("after %s", self.available_combinations[0])
         elif button == 3:
-            displayed = self.available_combinations[0]
-            combination, mode = self.combinations_map.get(displayed, (None, None))
-
-            if combination is None and mode is None:
-            # displayed combination cannot be activated, ignore
-              return
-
-            cmd = "xrandr"
-            outputs = self.connected
-            previous_output = None
-            for output in outputs:
-                cmd += f" --output {output}"
-                if output in combination:
-                    pos = getattr(self, f"{output}_pos", "0x0")
-                    resolution = getattr(self, f"{output}_mode", None)
-                    resolution = f"--mode {resolution}" if resolution else "--auto"
-                    rotation = "normal"
-                    if mode == "=" and previous_output is not None:
-                        cmd += f" {resolution} --same-as {previous_output}"
-                    else:
-                        if (
-                            "above" in pos
-                            or "below" in pos
-                            or "left-of" in pos
-                            or "right-of" in pos
-                           ):
-                            cmd += f" {resolution} --{pos} --rotate {rotation}"
-                        else:
-                            cmd += " {} --pos {} --rotate {}".format(
-                                resolution, pos, rotation
-                            )
-                    previous_output = output
-                else:
-                    cmd += " --off"
-
-            code = subprocess.run(cmd.split())
-            print(cmd)
-            print(code)
+            self.apply()
 

--- a/barpyrus/xrandr.py
+++ b/barpyrus/xrandr.py
@@ -1,0 +1,101 @@
+import subprocess
+import collections
+
+from itertools import combinations
+
+
+class Xrandr:
+    def __init__(self):
+        self.connected = list()
+        self.active_layout = list()
+        self.disconnected = list()
+        setattr(self, 'DP2-1_pos', 'left-of eDP1')
+        setattr(self, 'DP2-1_resolution', '1920x1080')
+
+    def get_layout(self):
+        proc = subprocess.run(["xrandr"], capture_output=True)
+        for line in proc.stdout.decode().splitlines():
+            s = line.split(" ")
+            if s[1] == "connected":
+                output, state, mode = s[0], s[1], None
+                for index, x in enumerate(s[2:], 2):
+                    if "x" in x and "+" in x:
+                        mode = x
+                        self.active_layout.append(output)
+                        infos = line[line.find(s[index + 1]) :]
+                        break
+                    elif "(" in x:
+                        break
+                self.connected.append(output)
+            elif s[1] == "disconnected":
+                output, state = s[0], s[1]
+                self.disconnected.append(output)
+    
+        return self.connected
+
+    def set_combinations(self, connected):
+        available = set()
+        combinations_map = {}
+
+        for output in range(len(connected)):
+            for comb in combinations(connected, output + 1):
+                for mode in ["=", "+"]:
+                    string = mode.join(comb)
+                    if len(comb) == 1:
+                        combinations_map[string] = (comb, None)
+                    else:
+                        combinations_map[string] = (comb, mode)
+                    available.add(string)
+ 
+        self.available_combinations = collections.deque(available)
+        self.combinations_map = combinations_map
+
+        return self.available_combinations
+    
+    def on_click(self, button):
+        print(button)
+
+        if button == 1:
+          print("before %s", self.available_combinations[0])
+          self.available_combinations.rotate()
+          print("after %s", self.available_combinations[0])
+        elif button == 3:
+            displayed = self.available_combinations[0]
+            combination, mode = self.combinations_map.get(displayed, (None, None))
+
+            if combination is None and mode is None:
+            # displayed combination cannot be activated, ignore
+              return
+
+            cmd = "xrandr"
+            outputs = self.connected
+            previous_output = None
+            for output in outputs:
+                cmd += f" --output {output}"
+                if output in combination:
+                    pos = getattr(self, f"{output}_pos", "0x0")
+                    resolution = getattr(self, f"{output}_mode", None)
+                    resolution = f"--mode {resolution}" if resolution else "--auto"
+                    rotation = "normal"
+                    if mode == "=" and previous_output is not None:
+                        cmd += f" {resolution} --same-as {previous_output}"
+                    else:
+                        if (
+                            "above" in pos
+                            or "below" in pos
+                            or "left-of" in pos
+                            or "right-of" in pos
+                           ):
+                            cmd += f" {resolution} --{pos} --rotate {rotation}"
+                        else:
+                            cmd += " {} --pos {} --rotate {}".format(
+                                resolution, pos, rotation
+                            )
+                    previous_output = output
+                else:
+                    cmd += " --off"
+
+            code = subprocess.run(cmd.split())
+            print(cmd)
+            print(code)
+

--- a/barpyrus/xrandr.py
+++ b/barpyrus/xrandr.py
@@ -18,20 +18,18 @@ class Xrandr:
         for line in proc.stdout.decode().splitlines():
             s = line.split(" ")
             if s[1] == "connected":
-                output, state, mode = s[0], s[1], None
+                output = s[0]
                 for index, x in enumerate(s[2:], 2):
                     if "x" in x and "+" in x:
-                        mode = x
                         active_layout.append(output)
-                        infos = line[line.find(s[index + 1]) :]
                         break
                     elif "(" in x:
                         break
                 self.connected.append(output)
             elif s[1] == "disconnected":
-                output, state = s[0], s[1]
+                output = s[0]
                 self.disconnected.append(output)
-    
+
         if self.active_layout is None:
             self.active_layout = self.active_mode.join(tuple(active_layout))
         return self.connected
@@ -49,15 +47,16 @@ class Xrandr:
                     else:
                         combinations_map[string] = (comb, mode)
                     available.add(string)
- 
+
         self.available_combinations = collections.deque(available)
         self.combinations_map = combinations_map
 
         return self.available_combinations
-    
+
     def choose_what_to_display(self):
         for _ in range(len(self.available_combinations)):
-            if self.displayed is None and self.available_combinations[0] == self.active_layout:
+            if self.displayed is None and \
+               self.available_combinations[0] == self.active_layout:
                 self.displayed = self.available_combinations[0]
                 break
             elif self.displayed == self.available_combinations[0]:
@@ -75,11 +74,12 @@ class Xrandr:
         if self.displayed == self.active_layout:
             return
 
-        combination, mode = self.combinations_map.get(self.displayed, (None, None))
+        combination, mode = self.combinations_map.get(
+                                self.displayed, (None, None))
 
         if combination is None and mode is None:
-        # displayed combination cannot be activated, ignore
-          return
+            # displayed combination cannot be activated, ignore
+            return
 
         cmd = "xrandr"
         outputs = self.connected
@@ -121,9 +121,8 @@ class Xrandr:
         print(button)
 
         if button == 1:
-          print("before %s", self.available_combinations[0])
-          self.switch_selection()
-          print("after %s", self.available_combinations[0])
+            print("before %s", self.available_combinations[0])
+            self.switch_selection()
+            print("after %s", self.available_combinations[0])
         elif button == 3:
             self.apply()
-


### PR DESCRIPTION
Hello,

I have been using this module for a while. I have based it off a similar module in py3status: 

https://github.com/ultrabug/py3status/blob/master/py3status/modules/xrandr.py

Let me know if there might be any interested into merging this module. The idea is that if you have a laptop display and you plug in an extra monitor, and for instance you have 'eDP1' and 'DP2-1' available, the script will show up an enumeration of:

['eDP1', 'DP2-1', 'eDP1+DP2-1', 'eDP1=DP2-1']

and you can cycle the enumeration with your left mouse. Then when you want to "commit" that xrandr property, you right click with the mouse and it executes the xrandr command to make it happen. So if you want to extend eDP1 and DP2-1, it is 'eDP1+DP2-1', and if you want to mirror them it is 'eDP1=DP2-1'. Or you can choose to either display eDP1 or DP2-1 only.

Here is an example of how I am currently using it in config file:

~~https://github.com/ultrabug/py3status/blob/master/py3status/modules/xrandr.py~~ (wrong link, sorry, please see answer below)

I am also willing to work on making the module better, I have not tested it much.